### PR TITLE
Fix depreciated unparenthesized `a ? b : c ? d : e`

### DIFF
--- a/index.php
+++ b/index.php
@@ -5,7 +5,7 @@
     // ##### NOTHING FURTHER TO CONFIGURE BELOW #####
     // ##############################################
 
-    $s = empty($_SERVER['HTTPS']) ? '' : ($_SERVER['HTTPS'] == 'on') ? 's' : '';
+    $s = (empty($_SERVER['HTTPS']) ? '' : ($_SERVER['HTTPS'] == 'on')) ? 's' : '';
     $base_url = "http$s://" . $_SERVER['HTTP_HOST'] . '/';
 
     $db = mysqli_connect($dbhost, $dbuser, $dbpass, $dbname) or error('Could not connect to database.', 500);


### PR DESCRIPTION
While working with your code, I got this error message:
```
Deprecated: Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)` in /home/mott/projects/contribute/simple-url-shortener/index.php on line 8
Nothing to do.
```

I am using the dev branch of PHP, but this shows that this will be depreciated in the future, and I see harm to the current code running on PHP7. 