### PR TITLE
Separate valid chars from random chars

### DIFF
--- a/config.sample.php
+++ b/config.sample.php
@@ -5,9 +5,11 @@
 	$dbpass = '';
 	$dbname = '';
 
-	// SET THE POSSIBLE CHARACTERS YOUR SHORT URL CAN USE...
+	// SET THE POSSIBLE CHARACTERS A RANDOM SHORT URL CAN USE...
 	// WE RECOMMEND USING 'abcdefghjkmnpqrstuvwxyz23456789', WHICH EXCLUDES AMBIGUOUS CHARACTERS SUCH AS O, 0, 1, I, L, etc.
-	$valid_chars = 'abcdefghjkmnpqrstuvwxyz23456789';
+	$random_chars = 'abcdefghjkmnpqrstuvwxyz23456789';
+	// SET THE ALLOWED CHARS WHEN PROCESSING URL
+	$valid_chars = 'abcdefghijklmnopqrstuvwxyz1234567890-_+~.';
 
 	// LENGTH OF YOUR SHORT URL SLUG...
 	$slug_length = 5;

--- a/index.php
+++ b/index.php
@@ -57,7 +57,7 @@
     }
 
     function createLink() {
-        global $base_url, $valid_chars, $slug_length, $db, $pw_create, $accepts_json;
+        global $base_url, $random_chars, $slug_length, $db, $pw_create, $accepts_json;
 
         $url = ltrim($_SERVER['REQUEST_URI'], '/');
 
@@ -68,7 +68,7 @@
         do {
             $possible_slug = '';
             for($i = 0; $i < $slug_length; $i++) {
-                $possible_slug .= $valid_chars[rand(0, strlen($valid_chars) - 1)];
+                $possible_slug .= $random_chars[rand(0, strlen($random_chars) - 1)];
             }
             $result = mysqli_query($db, "SELECT COUNT(*) FROM links WHERE slug = '$possible_slug'") or error('Could not generate new slug.', 500);
             $row = mysqli_fetch_row($result);


### PR DESCRIPTION
This allows a broader range of characters when parsing slugs, but maintains the non-confusing character list when creating a new slug. 

I got the list for the characters accepted from here: https://en.wikipedia.org/wiki/Percent-encoding#Types_of_URI_characters

This closes #5, and fixes the main problem behind the already closed #4.

Please note if anything needs changing.

This is also a precursor to the possibility of making custom slugs for URLs more easily than editing the database directly. 